### PR TITLE
to ignore direnv environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,5 @@ misc/
 backend/decodable_msgs
 backend/undecodable_msgs
 
+# direnv environment
+.envrc


### PR DESCRIPTION
Many people use 'direnv' to manage local environment. The config file '.envrc' must be ignored, as it creates clutter. 