### PR TITLE
Fixing error in whatsapp_binary_reader.py

### DIFF
--- a/backend/whatsapp_binary_reader.py
+++ b/backend/whatsapp_binary_reader.py
@@ -27,7 +27,7 @@ class WABinaryReader:
 		return ret;
 
 	def readInt16(self, littleEndian=False):
-		return readIntN(2, littleEndian);
+		return self.readIntN(2, littleEndian);
 
 	def readInt20(self):
 		self.checkEOS(3);
@@ -36,10 +36,10 @@ class WABinaryReader:
 		return ret;
 
 	def readInt32(self, littleEndian=False):
-		return readIntN(4, littleEndian);
+		return self.readIntN(4, littleEndian);
 
 	def readInt64(self, littleEndian=False):
-		return readIntN(8, littleEndian);
+		return self.readIntN(8, littleEndian);
 
 	def readPacked8(self, tag):
 		startByte = self.readByte();


### PR DESCRIPTION
Recently, I encountered this error and the following fix was able to solve it:
```
[ 'Traceback (most recent call last):',
[0]         '  File "/home/ubuntu/Schreibtisch/whatsapp-web-reveng/backend/whatsapp.py", line 159, in onMessage',
[0]         '    processedData = whatsappReadBinary(decryptedMessage, True);',
[0]         '  File "/home/ubuntu/Schreibtisch/whatsapp-web-reveng/backend/whatsapp_binary_reader.py", line 200, in whatsappReadBinary',
[0]         '    node = WABinaryReader(data).readNode();',
[0]         '  File "/home/ubuntu/Schreibtisch/whatsapp-web-reveng/backend/whatsapp_binary_reader.py", line 161, in readNode',
[0]         '    content = self.readList(tag);',
[0]         '  File "/home/ubuntu/Schreibtisch/whatsapp-web-reveng/backend/whatsapp_binary_reader.py", line 143, in readList',
[0]         '    for i in range(self.readListSize(tag)):',
[0]         '  File "/home/ubuntu/Schreibtisch/whatsapp-web-reveng/backend/whatsapp_binary_reader.py", line 95, in readListSize',
[0]         '    return self.readInt16();',
[0]         '  File "/home/ubuntu/Schreibtisch/whatsapp-web-reveng/backend/whatsapp_binary_reader.py", line 30, in readInt16',
[0]         '    return readIntN(2, littleEndian);',
[0]         'NameError: global name \'readIntN\' is not defined' ] },
```
