### PR TITLE
Run apt-get update & apt-get install in one layer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 FROM node
 
-RUN apt-get update
-
 # Install pip
-RUN apt-get -y install python-pip
+RUN apt-get update && apt-get install -y \
+    python-pip
+
 
 # Create app dir
 RUN mkdir /app


### PR DESCRIPTION
Each RUN command in a Dockerfile add's another layer, running update and install in different layers could cause issues, because the docker layers are cached. According to dockerfile's best practices this two command sould never be run in two statments.

See RUN/APT-GET in: https://docs.docker.com/develop/develop-images/dockerfile_best-practices/