### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 websocket-client
 git+https://github.com/dpallot/simple-websocket-server.git
 curve25519-donna
-pycrypto
+pycryptodome
 pyqrcode
 protobuf


### PR DESCRIPTION
Changed from `pycrypto` to `pycryptodome`.
The PyCrypto project is not maintained since the last commit on 23 Jun 2014. Instead of it, the PyCryptodome project (the fork of it) is maintained and is more stable.